### PR TITLE
Fix: Removed providing_args argument as it is deprecated

### DIFF
--- a/likes/signals.py
+++ b/likes/signals.py
@@ -6,5 +6,5 @@ __all__ = (
 )
 
 
-object_liked = Signal(providing_args=["like", "request"])
-object_unliked = Signal(providing_args=["object", "request"])
+object_liked = Signal()
+object_unliked = Signal()


### PR DESCRIPTION
- Removed providing_args argument as it is deprecated: https://docs.djangoproject.com/en/4.0/releases/3.1/#id2